### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/0xM4LL0C/yuji/security/code-scanning/1](https://github.com/0xM4LL0C/yuji/security/code-scanning/1)

To address the issue, we will add a `permissions` block at the workflow level (root level) to ensure that all jobs in the workflow inherit minimal permissions. Since the build job does not seem to require write access, we will set `contents: read` as the minimal starting point. 

This change will:
1. Add a `permissions` block at the root level of the `.github/workflows/build.yaml` file.
2. Ensure that the GITHUB_TOKEN used in this workflow has the least privilege, following the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
